### PR TITLE
also checking presence of $ITERM_SESSION_ID for ITERM support

### DIFF
--- a/plugin/togglecursor.vim
+++ b/plugin/togglecursor.vim
@@ -36,7 +36,7 @@ let s:supported_terminal = ''
 
 " Check for supported terminals.
 if !has("gui_running")
-    if $TERM_PROGRAM == "iTerm.app" || $KONSOLE_DBUS_SESSION != ""
+    if $TERM_PROGRAM == "iTerm.app" || exists("$ITERM_SESSION_ID") || $KONSOLE_DBUS_SESSION != ""
         " Konsole and  iTerm support using CursorShape.
         let s:supported_terminal = 'cursorshape'
     elseif $XTERM_VERSION != ''


### PR DESCRIPTION
checking for the existance of the $ITERM_SESSION_ID env variable is also an acceptable way of determining if you are using iterm or not. Worked perfectly here.

Thank for your plugin by the way!
