### PR TITLE
Update togglecursor.txt

### DIFF
--- a/doc/togglecursor.txt
+++ b/doc/togglecursor.txt
@@ -17,10 +17,10 @@ supported terminals.
 ==============================================================================
 SUPPORTED TERMINALS                              *togglecursor-supported*
 
-Currently supported terminals are iTerm2 for the Mac and KDE's Konsole.  The
-xterm console is partially supported as well.  Older xterm's didn't support
-the line cursor, so this plugin currently sets the cursor to underline
-instead.
+Currently supported terminals are iTerm2 for the Mac (version 1.0.0.20140518
+beta is required) and KDE's Konsole.  The xterm console is partially supported
+as well.  Older xterm's didn't support the line cursor, so this plugin
+currently sets the cursor to underline instead.
 
 The gnome-terminal application doesn't support changing the cursor via escape
 sequences and is not supported.  On unsupported terminals, Vim's default


### PR DESCRIPTION
Standard iTerm2 1.0.0 doesn't work; instead you get "q " appearing when vim tries to change the cursor shape. Just adding this point as clarity to the docs.
