### PR TITLE
Underline cursor for replace mode

### DIFF
--- a/plugin/togglecursor.vim
+++ b/plugin/togglecursor.vim
@@ -141,7 +141,7 @@ augroup ToggleCursorStartup
 		\ if v:insertmode == 'i' |
 		\	call <SID>ToggleCursorInsertMode(g:togglecursor_insert) |
 		\ elseif v:insertmode == 'r' |
-		\	call <SID>ToggleCursorInsertMode(g:togglecursor_replace)
+		\	call <SID>ToggleCursorInsertMode(g:togglecursor_replace) |
 		\ endif
     autocmd VimEnter * call <SID>ToggleCursorInit()
     autocmd VimLeave * call <SID>ToggleCursorLeave()


### PR DESCRIPTION
When I replace some text in Vim, I think it's better to use an underline cursor.
So I made the changes for this plugin.
