### PR TITLE
Enable it for Apple Terminal.app (needs MouseTerm)

### DIFF
--- a/plugin/togglecursor.vim
+++ b/plugin/togglecursor.vim
@@ -36,7 +36,8 @@ let s:supported_terminal = ''
 
 " Check for supported terminals.
 if !has("gui_running")
-    if $TERM_PROGRAM == "iTerm.app" || exists("$ITERM_SESSION_ID")
+    if $TERM_PROGRAM == "iTerm.app" || $TERM_PROGRAM == "Apple_Terminal"
+                \ || exists("$ITERM_SESSION_ID")
                 \ || $XTERM_VERSION != ""
                 \ || str2nr($VTE_VERSION) >= 3900
         " iTerm, xterm, and VTE based terminals support DESCCUSR.


### PR DESCRIPTION
Hi, a new release of MouseTerm (https://github.com/saitoha/mouseterm-plus) that enables DESCCUSR support in Terminal app has just been released. It would be nice to let vim-tooglecursor load with it :)

A different approach would be to add an option that forces the plugin loading.