### PR TITLE
Resolve #19 - Make cursor appears again inside tmux in gnome-terminal

### DIFF
--- a/plugin/togglecursor.vim
+++ b/plugin/togglecursor.vim
@@ -149,7 +149,9 @@ endfunction
 
 " Having our escape come first seems to work better with tmux and konsole under
 " Linux.
-let &t_ti = s:GetEscapeCode(g:togglecursor_default) . &t_ti
+if s:supported_terminal == 'cursorshape'
+    let &t_ti = s:GetEscapeCode(g:togglecursor_default) . &t_ti
+endif
 
 augroup ToggleCursorStartup
     autocmd!


### PR DESCRIPTION
This is my proposed fix for #19 . Basically I just added an if statement to check if we are currently in Konsole and only change ```&t_ti``` when we are inside Konsole. Otherwise, leave it untouched. This has worked perfectly for me in tmux under gnome-terminal and completely fixed #19 . What do you think?