### PR TITLE
Better support for some xterm versions.

### DIFF
--- a/plugin/togglecursor.vim
+++ b/plugin/togglecursor.vim
@@ -68,7 +68,7 @@ if exists("g:togglecursor_force") && g:togglecursor_force != ""
 endif
 
 function! s:GetXtermVersion(version)
-    return str2nr(matchstr(a:version, '\v^XTerm\(\zs\d+\ze\)'))
+    return str2nr(matchstr(a:version, '\v^(XTerm|X.Org .*)\(\zs\d+\ze\)'))
 endfunction
 
 if s:supported_terminal == ""


### PR DESCRIPTION
Sometimes, the $XTERM_VERSION variable looks like "Xorg a.b.c(xterm_version)", and not "Xterm (version).
