### PR TITLE
Add kitty support

### DIFF
--- a/doc/togglecursor.txt
+++ b/doc/togglecursor.txt
@@ -20,7 +20,7 @@ SUPPORTED TERMINALS                              *togglecursor-supported*
 Currently supported terminals are iTerm2 for the Mac (version 1.0.0.20130602
 beta or better is required), Mac's native Terminal (2.7 or better, starting in
 Sierra), rxvt-unicode (version 9.21 or better), VTE3 based terminals (including
-gnome-terminal), and KDE's Konsole.  XTerm 252 or better is supported as well.
+gnome-terminal), kitty (version 0.6 or better), and KDE's Konsole.  XTerm 252 or better is supported as well.
 XTerms younger than 282 don't support the line cursor, so this plugin currently
 sets the cursor to an underline instead for insert mode.
 

--- a/plugin/togglecursor.vim
+++ b/plugin/togglecursor.vim
@@ -81,6 +81,8 @@ if s:supported_terminal == ""
         let s:supported_terminal = 'xterm'
     elseif $TERM_PROGRAM == "Apple_Terminal" && str2nr($TERM_PROGRAM_VERSION) >= 388
         let s:supported_terminal = 'xterm'
+    elseif $TERM == "xterm-kitty"
+        let s:supported_terminal = 'xterm'
     elseif $TERM == "rxvt-unicode" || $TERM == "rxvt-unicode-256color"
         let s:supported_terminal = 'xterm'
     elseif str2nr($VTE_VERSION) >= 3900


### PR DESCRIPTION
This is a quick PR to add support for [kitty](https://github.com/kovidgoyal/kitty). Previously, the `$TERM` value of `xterm-kitty` wasn't captured, and now it is.

I've been using this variant for a few days now without any trouble, but please let me know if this isn't the correct approach.