### PR TITLE
Add option to change cursor color upon entering each mode

### DIFF
--- a/doc/togglecursor.txt
+++ b/doc/togglecursor.txt
@@ -120,8 +120,8 @@ The cursor can optionally be configured to change color depending on the mode.
 If no color is specified for a given mode, there will be no color change upon
 entering that mode.
 
-                                                 *togglecursor#insert_color*
-g:togglecursor#insert_color
+                                                 *togglecursor_insert_color*
+g:togglecursor_insert_color
 
 Type: |List| [|Number|, |Number|, |Number|]
 
@@ -129,13 +129,13 @@ The red, green, and blue colors to set the cursor when entering insert mode.
 Each color value ranges from 0 to 255, with 0 specifying no intensity, and 255
 specifying maximum intensity. For example: >
 
-    let g:togglecursor#insert_color = [0, 0, 255]
+    let g:togglecursor_insert_color = [0, 0, 255]
 <
 would set the cursor to blue upon entering insert mode.
 
 
-                                                 *togglecursor#replace_color*
-g:togglecursor#replace_color
+                                                 *togglecursor_replace_color*
+g:togglecursor_replace_color
 
 Type: |List| [|Number|, |Number|, |Number|]
 
@@ -143,12 +143,12 @@ The red, green, and blue colors to set the cursor when entering replace mode.
 Each color value ranges from 0 to 255, with 0 specifying no intensity, and 255
 specifying maximum intensity. For example: >
 
-    let g:togglecursor#replace_color = [255, 0, 255]
+    let g:togglecursor_replace_color = [255, 0, 255]
 <
 would set the cursor to magenta upon entering replace mode.
 
-                                                 *togglecursor#default_color*
-g:togglecursor#default_color
+                                                 *togglecursor_default_color*
+g:togglecursor_default_color
 
 Type: |List| [|Number|, |Number|, |Number|]
 
@@ -156,7 +156,7 @@ The red, green, and blue colors to set the cursor when entering normal or
 visual mode. Each color value ranges from 0 to 255, with 0 specifying no
 intensity, and 255 specifying maximum intensity. For example: >
 
-    let g:togglecursor#replace_color = [150, 150, 150]
+    let g:togglecursor_replace_color = [150, 150, 150]
 <
 would set the cursor to a medium grey upon entering normal or visual mode.
 

--- a/doc/togglecursor.txt
+++ b/doc/togglecursor.txt
@@ -159,6 +159,9 @@ intensity, and 255 specifying maximum intensity. For example: >
     let g:togglecursor_replace_color = [150, 150, 150]
 <
 would set the cursor to a medium grey upon entering normal or visual mode.
+If you want to set the cursor to a single color without it changing between
+modes, either only define the default color, or define all three mode colors
+to be same.
 
 ==============================================================================
 LIMITATIONS                                      *togglecursor-limitations*

--- a/doc/togglecursor.txt
+++ b/doc/togglecursor.txt
@@ -113,6 +113,53 @@ the correct cursor when first entering Vim.  Once you go into insert mode and
 back to normal mode, you'll find that the cursor has changed to the desired
 type.
 
+------------------------------------------------------------------------------
+COLORS                                           *togglecursor-colors*
+
+The cursor can optionally be configured to change color depending on the mode.
+If no color is specified for a given mode, there will be no color change upon
+entering that mode.
+
+                                                 *togglecursor#insert_color*
+g:togglecursor#insert_color
+
+Type: |List| [|Number|, |Number|, |Number|]
+
+The red, green, and blue colors to set the cursor when entering insert mode.
+Each color value ranges from 0 to 255, with 0 specifying no intensity, and 255
+specifying maximum intensity. For example: >
+
+    let g:togglecursor#insert_color = [0, 0, 255]
+<
+would set the cursor to blue upon entering insert mode.
+
+
+                                                 *togglecursor#replace_color*
+g:togglecursor#replace_color
+
+Type: |List| [|Number|, |Number|, |Number|]
+
+The red, green, and blue colors to set the cursor when entering replace mode.
+Each color value ranges from 0 to 255, with 0 specifying no intensity, and 255
+specifying maximum intensity. For example: >
+
+    let g:togglecursor#replace_color = [255, 0, 255]
+<
+would set the cursor to magenta upon entering replace mode.
+
+                                                 *togglecursor#default_color*
+g:togglecursor#default_color
+
+Type: |List| [|Number|, |Number|, |Number|]
+
+The red, green, and blue colors to set the cursor when entering normal or
+visual mode. Each color value ranges from 0 to 255, with 0 specifying no
+intensity, and 255 specifying maximum intensity. For example: >
+
+    let g:togglecursor#replace_color = [150, 150, 150]
+<
+would set the cursor to a medium grey upon entering normal or visual mode.
+
 ==============================================================================
 LIMITATIONS                                      *togglecursor-limitations*
 

--- a/plugin/togglecursor.vim
+++ b/plugin/togglecursor.vim
@@ -56,6 +56,7 @@ let s:xterm_blinking_underline = "\<Esc>[3 q"
 " Putty has limited support
 let s:putty_line = "\<Esc>[=1c"
 let s:putty_block = "\<Esc>[=2c"
+let s:putty_underline = "\<Esc>[=2c"
 
 let s:in_tmux = exists("$TMUX")
 let s:in_nested_tmux = exists("$TMUX_NESTED")

--- a/plugin/togglecursor.vim
+++ b/plugin/togglecursor.vim
@@ -58,6 +58,8 @@ let s:putty_line = "\<Esc>[=1c"
 let s:putty_block = "\<Esc>[=2c"
 
 let s:in_tmux = exists("$TMUX")
+let s:in_nested_tmux = exists("$TMUX_NESTED")
+let s:in_remote_tmux = exists("$TMUX_REMOTE")
 
 " Detect whether this version of vim supports changing the replace cursor
 " natively.
@@ -100,7 +102,7 @@ if s:supported_terminal == ""
         " box under KDE.
 
         let s:supported_terminal = 'cursorshape'
-    elseif $PUTTY != ""
+    elseif exists("$PUTTY")
         let s:supported_terminal = 'putty'
     endif
 endif
@@ -168,7 +170,15 @@ function! s:GetEscapeCode(shape)
     let l:escape_code = s:{s:supported_terminal}_{a:shape}
 
     if s:in_tmux
-        return s:TmuxEscape(l:escape_code)
+        let l:escape_code = s:TmuxEscape(l:escape_code)
+    endif
+
+    if s:in_nested_tmux
+        let l:escape_code = s:TmuxEscape(l:escape_code)
+    endif
+
+    if s:in_remote_tmux
+        let l:escape_code = s:TmuxEscape(l:escape_code)
     endif
 
     return l:escape_code

--- a/plugin/togglecursor.vim
+++ b/plugin/togglecursor.vim
@@ -211,10 +211,10 @@ function! s:ToggleCursorInit()
         return
     endif
 
-    let &t_EI = s:GetEscapeCode(g:togglecursor_default, g:cursorcolor_default)
-    let &t_SI = s:GetEscapeCode(g:togglecursor_insert, g:cursorcolor_insert)
+    let &t_EI = s:GetEscapeCode(g:togglecursor_default, s:cursorcolor_default)
+    let &t_SI = s:GetEscapeCode(g:togglecursor_insert, s:cursorcolor_insert)
     if s:sr_supported
-        let &t_SR = s:GetEscapeCode(g:togglecursor_replace, g:cursorcolor_replace)
+        let &t_SR = s:GetEscapeCode(g:togglecursor_replace, s:cursorcolor_replace)
     endif
 endfunction
 
@@ -222,23 +222,23 @@ function! s:ToggleCursorLeave()
     " One of the last codes emitted to the terminal before exiting is the "out
     " of termcap" sequence.  Tack our escape sequence to change the cursor type
     " onto the beginning of the sequence.
-    let &t_te = s:GetEscapeCode(g:togglecursor_leave, g:cursorcolor_leave) . &t_te
+    let &t_te = s:GetEscapeCode(g:togglecursor_leave, s:cursorcolor_leave) . &t_te
 endfunction
 
 function! s:ToggleCursorByMode()
     if v:insertmode == 'r' || v:insertmode == 'v'
-        let &t_SI = s:GetEscapeCode(g:togglecursor_replace)
+        let &t_SI = s:GetEscapeCode(g:togglecursor_replace, s:cursorcolor_replace)
     else
         " Default to the insert mode cursor.
-        let &t_SI = s:GetEscapeCode(g:togglecursor_insert)
+        let &t_SI = s:GetEscapeCode(g:togglecursor_insert, s:cursorcolor_insert)
     endif
 endfunction
 
 function! s:ToggleCursorRefresh()
     if mode() == 'n'
-        call writefile([s:GetEscapeCode(g:togglecursor_default)], '/dev/tty', 'b')
+        call writefile([s:GetEscapeCode(g:togglecursor_default, s:cursorcolor_default)], '/dev/tty', 'b')
     elseif mode() == 'i'
-        call writefile([s:GetEscapeCode(g:togglecursor_insert)], '/dev/tty', 'b')
+        call writefile([s:GetEscapeCode(g:togglecursor_insert, s:cursorcolor_default)], '/dev/tty', 'b')
     endif
 endfunction
 
@@ -248,7 +248,7 @@ endfunction
 " 0.40.2-based terminals seem to have issues with the cursor disappearing in the
 " certain environments.
 if g:togglecursor_disable_default_init == 0
-    let &t_ti = s:GetEscapeCode(g:togglecursor_default) . &t_ti
+    let &t_ti = s:GetEscapeCode(g:togglecursor_default, s:cursorcolor_leave) . &t_ti
 endif
 
 augroup ToggleCursorStartup

--- a/plugin/togglecursor.vim
+++ b/plugin/togglecursor.vim
@@ -90,7 +90,7 @@ if s:supported_terminal == ""
         let s:supported_terminal = 'xterm'
     elseif $TERM == "xterm-kitty"
         let s:supported_terminal = 'xterm'
-    elseif $TERM == "rxvt-unicode" || $TERM == "rxvt-unicode-256color"
+    elseif $TERM == "rxvt-unicode" || $TERM == "rxvt-unicode-256color" || $TERM == "xterm-256color"
         let s:supported_terminal = 'xterm'
     elseif str2nr($VTE_VERSION) >= 3900
         let s:supported_terminal = 'xterm'

--- a/plugin/togglecursor.vim
+++ b/plugin/togglecursor.vim
@@ -107,9 +107,10 @@ if s:supported_terminal == ""
         let s:supported_terminal = 'xterm'
     elseif $TERM == "xterm-kitty"
         let s:supported_terminal = 'xterm'
-    elseif $TERM == "rxvt-unicode" 
+    elseif $TERM == "rxvt-unicode"
                 \ || $TERM == "rxvt-unicode-256color"
                 \ || $TERM == "xterm-256color"
+                \ || $TERM == "xterm-color"
                 \ || $TERM == "screen-256color"
                 \ || $TERM == "screen-256color-bce"
         let s:supported_terminal = 'xterm'

--- a/plugin/togglecursor.vim
+++ b/plugin/togglecursor.vim
@@ -34,21 +34,25 @@ endif
 
 let g:loaded_togglecursor = 1
 
-" @param[in] Number decimal   number to convert to hexidecimal
-" @return String hexidecimal number
-function! s:DecimalToHex(decimal)
-    return printf('%x', a:decimal)
+" Get the escape code for changing the cursor color
+"
+" @param[in] List<Number>   rgb values of a specified color
+" @return String escape code to alter the cursor to the corresponding color
+function! s:GetColorEscapeCode(color)
+    return "\<Esc>]12;rgb:"
+                \ . printf('%x/%x/%x', a:color[0], a:color[1], a:color[2])
+                \ ."/79\x7"
 endfunction
 
-let s:cursorcolor_blue = "\<Esc>]12;rgb:61/af/ef\x7"
-let s:cursorcolor_red = "\<Esc>]12;rgb:e0/6c/75\x7"
-let s:cursorcolor_green = "\<Esc>]12;rgb:98/c3/79\x7"
-let s:cursorcolor_white = "\<Esc>]12;rgb:98/c3/79\x7"
-let s:cursorcolor_insert = s:cursorcolor_blue
-let s:cursorcolor_replace = s:cursorcolor_red
-let s:cursorcolor_default = s:cursorcolor_green
-" let s:cursorcolor_leave = "\<Esc>]112;"
-let s:cursorcolor_leave = ""
+" Only alter colors if the user has defined the color values for each mode
+let s:cursorcolor_insert = exists("g:togglecursor#insert_color") ?
+            \ s:GetColorEscapeCode(g:togglecursor#insert_color) : ""
+let s:cursorcolor_replace = exists("g:togglecursor#replace_color") ?
+            \ s:GetColorEscapeCode(g:togglecursor#replace_color) : ""
+let s:cursorcolor_default = exists("g:togglecursor#default_color") ?
+            \ s:GetColorEscapeCode(g:togglecursor#default_color) : ""
+
+let s:cursorcolor_leave = "\033]112\007"
 
 let s:cursorshape_underline = "\<Esc>]50;CursorShape=2;BlinkingCursorEnabled=0\x7"
 let s:cursorshape_line = "\<Esc>]50;CursorShape=1;BlinkingCursorEnabled=0\x7"
@@ -223,7 +227,8 @@ function! s:ToggleCursorLeave()
     " One of the last codes emitted to the terminal before exiting is the "out
     " of termcap" sequence.  Tack our escape sequence to change the cursor type
     " onto the beginning of the sequence.
-    let &t_te = s:GetEscapeCode(g:togglecursor_leave, s:cursorcolor_leave) . &t_te
+    let &t_te = s:GetEscapeCode(g:togglecursor_leave, s:cursorcolor_leave)
+                \ . &t_te
 endfunction
 
 function! s:ToggleCursorByMode()

--- a/plugin/togglecursor.vim
+++ b/plugin/togglecursor.vim
@@ -90,7 +90,7 @@ if s:supported_terminal == ""
         let s:supported_terminal = 'xterm'
     elseif $TERM == "xterm-kitty"
         let s:supported_terminal = 'xterm'
-    elseif $TERM == "rxvt-unicode" || $TERM == "rxvt-unicode-256color" || $TERM == "xterm-256color"
+    elseif $TERM == "rxvt-unicode" || $TERM == "rxvt-unicode-256color" || $TERM == "xterm-256color" || $TERM == "screen-256color" || $TERM == "screen-256color-bce"
         let s:supported_terminal = 'xterm'
     elseif str2nr($VTE_VERSION) >= 3900
         let s:supported_terminal = 'xterm'

--- a/plugin/togglecursor.vim
+++ b/plugin/togglecursor.vim
@@ -86,11 +86,16 @@ if s:supported_terminal == ""
     " iTerm, xterm, and VTE based terminals support DECSCUSR.
     if $TERM_PROGRAM == "iTerm.app" || exists("$ITERM_SESSION_ID")
         let s:supported_terminal = 'xterm'
-    elseif $TERM_PROGRAM == "Apple_Terminal" && str2nr($TERM_PROGRAM_VERSION) >= 388
+    elseif $TERM_PROGRAM == "Apple_Terminal"
+                \ && str2nr($TERM_PROGRAM_VERSION) >= 388
         let s:supported_terminal = 'xterm'
     elseif $TERM == "xterm-kitty"
         let s:supported_terminal = 'xterm'
-    elseif $TERM == "rxvt-unicode" || $TERM == "rxvt-unicode-256color" || $TERM == "xterm-256color" || $TERM == "screen-256color" || $TERM == "screen-256color-bce"
+    elseif $TERM == "rxvt-unicode" 
+                \ || $TERM == "rxvt-unicode-256color"
+                \ || $TERM == "xterm-256color"
+                \ || $TERM == "screen-256color"
+                \ || $TERM == "screen-256color-bce"
         let s:supported_terminal = 'xterm'
     elseif str2nr($VTE_VERSION) >= 3900
         let s:supported_terminal = 'xterm'

--- a/plugin/togglecursor.vim
+++ b/plugin/togglecursor.vim
@@ -34,6 +34,10 @@ endif
 
 let g:loaded_togglecursor = 1
 
+let s:cursorcolor_blue = "\<Esc>]12;rgb:61/af/ef\x7"
+let s:cursorcolor_red = "\<Esc>]12;rgb:e0/6c/75\x7"
+let s:cursorcolor_green = "\<Esc>]12;rgb:98/c3/79\x7"
+
 let s:cursorshape_underline = "\<Esc>]50;CursorShape=2;BlinkingCursorEnabled=0\x7"
 let s:cursorshape_line = "\<Esc>]50;CursorShape=1;BlinkingCursorEnabled=0\x7"
 let s:cursorshape_block = "\<Esc>]50;CursorShape=0;BlinkingCursorEnabled=0\x7"

--- a/plugin/togglecursor.vim
+++ b/plugin/togglecursor.vim
@@ -53,6 +53,10 @@ let s:xterm_blinking_block = "\<Esc>[0 q"
 let s:xterm_blinking_line = "\<Esc>[5 q"
 let s:xterm_blinking_underline = "\<Esc>[3 q"
 
+" Putty has limited support
+let s:putty_line = "\<Esc>[=1c"
+let s:putty_block = "\<Esc>[=2c"
+
 let s:in_tmux = exists("$TMUX")
 
 " Detect whether this version of vim supports changing the replace cursor
@@ -96,6 +100,8 @@ if s:supported_terminal == ""
         " box under KDE.
 
         let s:supported_terminal = 'cursorshape'
+    elseif $PUTTY != ""
+        let s:supported_terminal = 'putty'
     endif
 endif
 

--- a/plugin/togglecursor.vim
+++ b/plugin/togglecursor.vim
@@ -45,12 +45,12 @@ function! s:GetColorEscapeCode(color)
 endfunction
 
 " Only alter colors if the user has defined the color values for each mode
-let s:cursorcolor_insert = exists("g:togglecursor#insert_color") ?
-            \ s:GetColorEscapeCode(g:togglecursor#insert_color) : ""
-let s:cursorcolor_replace = exists("g:togglecursor#replace_color") ?
-            \ s:GetColorEscapeCode(g:togglecursor#replace_color) : ""
-let s:cursorcolor_default = exists("g:togglecursor#default_color") ?
-            \ s:GetColorEscapeCode(g:togglecursor#default_color) : ""
+let s:cursorcolor_insert = exists("g:togglecursor_insert_color") ?
+            \ s:GetColorEscapeCode(g:togglecursor_insert_color) : ""
+let s:cursorcolor_replace = exists("g:togglecursor_replace_color") ?
+            \ s:GetColorEscapeCode(g:togglecursor_replace_color) : ""
+let s:cursorcolor_default = exists("g:togglecursor_default_color") ?
+            \ s:GetColorEscapeCode(g:togglecursor_default_color) : ""
 
 let s:cursorcolor_leave = "\033]112\007"
 

--- a/plugin/togglecursor.vim
+++ b/plugin/togglecursor.vim
@@ -34,9 +34,21 @@ endif
 
 let g:loaded_togglecursor = 1
 
+" @param[in] Number decimal   number to convert to hexidecimal
+" @return String hexidecimal number
+function! s:DecimalToHex(decimal)
+    return printf('%x', a:decimal)
+endfunction
+
 let s:cursorcolor_blue = "\<Esc>]12;rgb:61/af/ef\x7"
 let s:cursorcolor_red = "\<Esc>]12;rgb:e0/6c/75\x7"
 let s:cursorcolor_green = "\<Esc>]12;rgb:98/c3/79\x7"
+let s:cursorcolor_white = "\<Esc>]12;rgb:98/c3/79\x7"
+let s:cursorcolor_insert = s:cursorcolor_blue
+let s:cursorcolor_replace = s:cursorcolor_red
+let s:cursorcolor_default = s:cursorcolor_green
+" let s:cursorcolor_leave = "\<Esc>]112;"
+let s:cursorcolor_leave = ""
 
 let s:cursorshape_underline = "\<Esc>]50;CursorShape=2;BlinkingCursorEnabled=0\x7"
 let s:cursorshape_line = "\<Esc>]50;CursorShape=1;BlinkingCursorEnabled=0\x7"
@@ -172,12 +184,12 @@ function! s:SupportedTerminal()
     return 1
 endfunction
 
-function! s:GetEscapeCode(shape)
+function! s:GetEscapeCode(shape, color)
     if !s:SupportedTerminal()
         return ''
     endif
 
-    let l:escape_code = s:{s:supported_terminal}_{a:shape}
+    let l:escape_code = s:{s:supported_terminal}_{a:shape} . a:color
 
     if s:in_tmux
         let l:escape_code = s:TmuxEscape(l:escape_code)
@@ -199,10 +211,10 @@ function! s:ToggleCursorInit()
         return
     endif
 
-    let &t_EI = s:GetEscapeCode(g:togglecursor_default)
-    let &t_SI = s:GetEscapeCode(g:togglecursor_insert)
+    let &t_EI = s:GetEscapeCode(g:togglecursor_default, g:cursorcolor_default)
+    let &t_SI = s:GetEscapeCode(g:togglecursor_insert, g:cursorcolor_insert)
     if s:sr_supported
-        let &t_SR = s:GetEscapeCode(g:togglecursor_replace)
+        let &t_SR = s:GetEscapeCode(g:togglecursor_replace, g:cursorcolor_replace)
     endif
 endfunction
 
@@ -210,7 +222,7 @@ function! s:ToggleCursorLeave()
     " One of the last codes emitted to the terminal before exiting is the "out
     " of termcap" sequence.  Tack our escape sequence to change the cursor type
     " onto the beginning of the sequence.
-    let &t_te = s:GetEscapeCode(g:togglecursor_leave) . &t_te
+    let &t_te = s:GetEscapeCode(g:togglecursor_leave, g:cursorcolor_leave) . &t_te
 endfunction
 
 function! s:ToggleCursorByMode()

--- a/plugin/togglecursor.vim
+++ b/plugin/togglecursor.vim
@@ -7,7 +7,7 @@
 " ============================================================================
 
 if exists('g:loaded_togglecursor') || &cp || !has("cursorshape")
-  finish
+    finish
 endif
 
 " Bail out early if not running under a terminal.
@@ -202,6 +202,14 @@ function! s:ToggleCursorByMode()
     endif
 endfunction
 
+function! s:ToggleCursorRefresh()
+    if mode() == 'n'
+        call writefile([s:GetEscapeCode(g:togglecursor_default)], '/dev/tty', 'b')
+    elseif mode() == 'i'
+        call writefile([s:GetEscapeCode(g:togglecursor_insert)], '/dev/tty', 'b')
+    endif
+endfunction
+
 " Setting t_ti allows us to get the cursor correct for normal mode when we first
 " enter Vim.  Having our escape come first seems to work better with tmux and
 " Konsole under Linux.  Allow users to turn this off, since some users of VTE
@@ -218,4 +226,6 @@ augroup ToggleCursorStartup
     if !s:sr_supported
         autocmd InsertEnter * call <SID>ToggleCursorByMode()
     endif
+    autocmd CursorMoved * call <SID>ToggleCursorRefresh()
+    autocmd CursorMovedI * call <SID>ToggleCursorRefresh()
 augroup END


### PR DESCRIPTION
v6.0.0
Add `g:togglecursor_insert_color`, `g:togglecursor_replace_color`, and `g:togglecursor_default_color` variables to specify the RGB values of the cursor for entering those modes. Completely optional. If the user does not specify these values themselves, then no color change occurs. These values are explained in the help docs.

Later done the road, I was thinking about adding an option for the cursor to change color based on the selected color scheme, similar to how [airline](https://github.com/vim-airline/vim-airline), or [lightline](https://github.com/itchyny/lightline.vim) can match their mode colors to a specified color scheme. This would be a lot easier than manually settings RGB values.

Add terminal support for `xterm-color`. Tested and successfully works for [Git bash](https://git-scm.com/downloads).

Add additional support from forked repos of [caipre](https://github.com/caipre) and [ianisl](https://github.com/ianisl). Resolve merge conflicts but have not tested them.

Any feedback on changes I should make would be appreciated.