### PR TITLE
Support for gnu screen

### DIFF
--- a/doc/togglecursor.txt
+++ b/doc/togglecursor.txt
@@ -74,6 +74,17 @@ tmux has supported the ability to directly change the cursor for some time now.
 If you're using an old version that cannot handle this, then you can enable the
 old escaping behavior.  This shouldn't be necessary with modern tmux.
 
+                                       *togglecursor_enable_gnu_screen_escaping*
+Enables GNU Screen support by checking if the 'STY' environment variable is set.
+When turned on, the cursor toggle should behave as expected both within a screen
+session and when exiting screen.
+
+To turn it on, you can set the g:togglecursor_enable_gnu_screen_escaping
+to a non-zero value in your vimrc: >
+
+    let g:togglecursor_enable_gnu_screen_escaping = 1
+<
+
                                                  *togglecursor_disable_neovim*
 Note: This option is no longer supported.  Neovim adopted a different mechanism
 for enabling the cursor, so this is no longer necessary.

--- a/plugin/togglecursor.vim
+++ b/plugin/togglecursor.vim
@@ -127,6 +127,15 @@ else
     let s:in_tmux = 0
 endif
 
+if !exists("g:togglecursor_enable_gnu_screen_escaping")
+    let g:togglecursor_enable_gnu_screen_escaping = 0
+endif
+
+if g:togglecursor_enable_gnu_screen_escaping
+    let s:in_gnu_screen = exists("$STY")
+else
+    let s:in_gnu_screen = 0
+endif
 
 " -------------------------------------------------------------
 " Functions
@@ -136,6 +145,11 @@ function! s:TmuxEscape(line)
     " Tmux has an escape hatch for talking to the real terminal.  Use it.
     let escaped_line = substitute(a:line, "\<Esc>", "\<Esc>\<Esc>", 'g')
     return "\<Esc>Ptmux;" . escaped_line . "\<Esc>\\"
+endfunction
+
+function! s:GnuScreenEscape(line)
+    let escaped_line = substitute(a:line, "\<Esc>", "\eP\e", 'g')
+    return escaped_line . "\e\\"
 endfunction
 
 function! s:SupportedTerminal()
@@ -155,6 +169,10 @@ function! s:GetEscapeCode(shape)
 
     if s:in_tmux
         return s:TmuxEscape(l:escape_code)
+    endif
+
+    if s:in_gnu_screen
+        return s:GnuScreenEscape(l:escape_code)
     endif
 
     return l:escape_code


### PR DESCRIPTION
This is a PR to support GNU Screen

How it works is when you are within a screen session the `STY` environment variable is set and is detected by the 
plugin when the `togglecursor_enable_gnu_screen_escaping` is set.
If you exit screen, `STY` will not be set anymore and and the plugin will use the normal escape sequences.

I decided to not automatically detect if GNU Screen is set if for some reason it breaks compatibility for someone, although
I do not think it does since `STY` is supposed to be a GNU Screen only environment variable.