### PR TITLE
Add support for Ghostty

### DIFF
--- a/doc/togglecursor.txt
+++ b/doc/togglecursor.txt
@@ -20,10 +20,10 @@ SUPPORTED TERMINALS                              *togglecursor-supported*
 Currently supported terminals are iTerm2 for the Mac (version 1.0.0.20130602
 beta or better is required), Mac's native Terminal (2.7 or better, starting in
 Sierra), rxvt-unicode (version 9.21 or better), VTE3 based terminals (including
-gnome-terminal), kitty (version 0.6 or better), WezTerm, and KDE's Konsole.
-XTerm 252 or better is supported as well.  XTerms younger than 282 don't support
-the line cursor, so this plugin currently sets the cursor to an underline
-instead for insert mode.
+gnome-terminal), kitty (version 0.6 or better), WezTerm, Ghostty, and KDE's
+Konsole.  XTerm 252 or better is supported as well.  XTerms younger than 282
+don't support the line cursor, so this plugin currently sets the cursor to an
+underline instead for insert mode.
 
 Older versions of VTE3 based terminals (before v0.39) do not support changing 
 the cursor via escape sequences and are not supported.  On unsupported 

--- a/plugin/togglecursor.vim
+++ b/plugin/togglecursor.vim
@@ -68,6 +68,8 @@ if s:supported_terminal == ""
         let s:supported_terminal = 'xterm'
     elseif $TERM_PROGRAM == "WezTerm"
         let s:supported_terminal = 'xterm'
+    elseif $TERM_PROGRAM == "ghostty"
+        let s:supported_terminal = 'xterm'
     elseif $TERM == "xterm-kitty"
         let s:supported_terminal = 'xterm'
     elseif $TERM == "rxvt-unicode" || $TERM == "rxvt-unicode-256color"


### PR DESCRIPTION
Add support for the [Ghostty](https://github.com/ghostty-org/ghostty) terminal following its recent public release.

This PR follows the convention from 9c8cec90858d48986d7162fdc6ac96a2aff1979d where support was added for WezTerm.